### PR TITLE
Make dist and RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cligen_hello
 cligen_file
 cligen_tutorial
 autom4te.cache
+build-root/*.tar.xz
 
 # Object files
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ cligen_file
 cligen_tutorial
 autom4te.cache
 build-root/*.tar.xz
+build-root/*.rpm
+build-root/rpmbuild
 
 # Object files
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@ build.c
 cligen_parse.tab.c
 cligen_parse.tab.h
 lex.cligen_parse.c
+cligen_config.h
+Makefile
+config.log
+config.status
+cligen
+cligen_hello
+cligen_file
+cligen_tutorial
+autom4te.cache
 
 # Object files
 *.o

--- a/Makefile.in
+++ b/Makefile.in
@@ -87,6 +87,40 @@ distclean: clean
 	rm -f Makefile config.log config.status config.h TAGS .depend
 	rm -rf autom4te.cache build.c cligen_config.h
 	rm -rf doc
+	rm -f build-root/*.tar.xz
+
+export BR=$(CURDIR)/build-root
+
+$(BR)/scripts/.version:
+ifneq ("$(wildcard /etc/redhat-release)","")
+	$(shell $(BR)/scripts/version rpm-string > $(BR)/scripts/.version)
+else
+	$(shell $(BR)/scripts/version > $(BR)/scripts/.version)
+endif
+
+DIST_FILE = $(BR)/cligen-$(shell extras/scripts/version).tar
+DIST_SUBDIR = cligen-$(shell extras/scripts/version | cut -f1 -d-)
+
+dist:
+	@if git rev-parse 2> /dev/null ; then \
+	    git archive \
+	      --prefix=$(DIST_SUBDIR)/ \
+	      --format=tar \
+	      -o $(DIST_FILE) \
+	    HEAD ; \
+	    git describe > $(BR)/.version ; \
+	else \
+	    (cd .. ; tar -cf $(DIST_FILE) $(DIST_SUBDIR) --exclude=*.tar) ; \
+	    extras/scripts/version > $(BR)/.version ; \
+	fi
+	@tar --append \
+	  --file $(DIST_FILE) \
+	  --transform='s,.*/.version,$(DIST_SUBDIR)/extras/scripts/.version,' \
+	  $(BR)/.version
+	@$(RM) $(BR)/.version $(DIST_FILE).xz
+	@xz -v --threads=0 $(DIST_FILE)
+	@$(RM) $(BR)/cligen-latest.tar.xz
+	@ln -rs $(DIST_FILE).xz $(BR)/cligen-latest.tar.xz
 
 # Default rule  .c.o:	
 %@OBJ_SUFFIX@ : @srcdir@/%.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -86,8 +86,8 @@ TAGS:
 distclean: clean
 	rm -f Makefile config.log config.status config.h TAGS .depend
 	rm -rf autom4te.cache build.c cligen_config.h
-	rm -rf doc
-	rm -f build-root/*.tar.xz
+	rm -rf doc build-root/rpmbuild
+	rm -f build-root/*.tar.xz build-root/*.rpm extras/rpm/Makefile
 
 export BR=$(CURDIR)/build-root
 
@@ -121,6 +121,12 @@ dist:
 	@xz -v --threads=0 $(DIST_FILE)
 	@$(RM) $(BR)/cligen-latest.tar.xz
 	@ln -rs $(DIST_FILE).xz $(BR)/cligen-latest.tar.xz
+
+pkg-rpm: dist
+	make -C extras/rpm
+
+pkg-srpm: dist
+	make -C extras/rpm srpm
 
 # Default rule  .c.o:	
 %@OBJ_SUFFIX@ : @srcdir@/%.c

--- a/build-root/scripts/version
+++ b/build-root/scripts/version
@@ -1,0 +1,1 @@
+../../extras/scripts/version

--- a/configure
+++ b/configure
@@ -3792,7 +3792,7 @@ done
 
 
 
-ac_config_files="$ac_config_files Makefile"
+ac_config_files="$ac_config_files Makefile extras/rpm/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -4485,6 +4485,7 @@ do
   case $ac_config_target in
     "cligen_config.h") CONFIG_HEADERS="$CONFIG_HEADERS cligen_config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "extras/rpm/Makefile") CONFIG_FILES="$CONFIG_FILES extras/rpm/Makefile" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -126,5 +126,8 @@ AC_CHECK_HEADERS(regex.h termios.h)
 
 AH_BOTTOM([#include <cligen_custom.h>])
 
-AC_OUTPUT(Makefile)
+AC_OUTPUT([
+	Makefile
+	extras/rpm/Makefile
+])
 

--- a/extras/rpm/Makefile.in
+++ b/extras/rpm/Makefile.in
@@ -1,0 +1,32 @@
+TARBALL=$(shell realpath ../../build-root/cligen-latest.tar.xz)
+BASENAME=$(shell basename $(TARBALL) | sed -e s/.tar.\*//)
+VERSION=$(shell echo $(BASENAME) | cut -f2 -d-)
+RELEASE=$(shell echo $(BASENAME) | cut -f3- -d- | sed -e s/-/_/g)
+BR=$(shell realpath $(CURDIR)/../../build-root)
+RPMBUILD=$(BR)/rpmbuild
+
+all: RPM
+
+spec:
+	@echo $(TARBALL)
+	mkdir -p $(RPMBUILD)/{RPMS,SRPMS,BUILD,SOURCES,SPECS}
+	cp $(TARBALL) $(RPMBUILD)/SOURCES/cligen-$(VERSION)-$(RELEASE).tar.xz
+	cp cligen.spec $(RPMBUILD)/SPECS
+
+srpm: spec
+	rpmbuild -bs \
+	  --define "_prefix @prefix@" \
+	  --define "_topdir $(RPMBUILD)" \
+	  --define "_version $(VERSION)" \
+	  --define "_release $(RELEASE)" \
+	  $(RPMBUILD)/SPECS/cligen.spec
+	mv $$(find $(RPMBUILD)/SRPMS -name \*.src.rpm -type f) $(BR)
+
+RPM: spec
+	rpmbuild -bb \
+	  --define "_prefix @prefix@" \
+	  --define "_topdir $(RPMBUILD)" \
+	  --define "_version $(VERSION)" \
+	  --define "_release $(RELEASE)" \
+	  $(RPMBUILD)/SPECS/cligen.spec
+	mv $$(find $(RPMBUILD)/RPMS -name \*.rpm -type f) $(BR)

--- a/extras/rpm/cligen.spec
+++ b/extras/rpm/cligen.spec
@@ -1,0 +1,48 @@
+%{!?_topdir: %define _topdir %(pwd)}
+
+Name: cligen
+Version: %{_version}
+Release: %{_release}
+Summary: The CLIGEN command line generation tool
+Group: System Environment/Libraries
+License: ASL 2.0 or GPLv2
+URL: http://www.cligen.se
+AutoReq: no
+BuildRequires: flex, bison
+
+Source: %{name}-%{version}-%{release}.tar.xz
+
+%description
+The CLIGEN command line generation tool.
+
+%package devel
+Summary: CLIGEN header files
+Group: Development/Libraries
+Requires: cligen
+
+%description devel
+This package contains header files for CLIGEN.
+
+%prep
+%setup
+
+%build
+./configure --prefix=%{_prefix} --libdir=%{_libdir}
+make
+
+%install
+make DESTDIR=${RPM_BUILD_ROOT} install
+
+%files
+%{_libdir}/lib*
+
+%files devel
+%{_includedir}/%{name}/*
+
+%clean
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig

--- a/extras/scripts/version
+++ b/extras/scripts/version
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Obtained from VPP - https://wiki.fd.io/view/VPP
+#
+
+path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
+
+cd "$path"
+
+if [ -f .version ]; then
+    vstring=$(cat .version)
+else
+    vstring=$(git describe)
+    if [ $? != 0 ]; then
+      exit 1
+    fi
+fi
+
+TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^[vR]//')
+ADD=$(echo ${vstring} | cut -s -d- -f2)
+
+git rev-parse 2> /dev/null
+if [ $? == 0 ]; then
+    CMT=$(git describe --dirty --match '[vR]*'| cut -s -d- -f3,4)
+else
+    CMT=$(echo ${vstring} | cut -s -d- -f3,4)
+fi
+CMTR=$(echo $CMT | sed 's/-/_/')
+
+if [ -n "${BUILD_NUMBER}" ]; then
+       BLD="~b${BUILD_NUMBER}"
+fi
+
+if [ "$1" = "rpm-version" ]; then
+  echo ${TAG}
+  exit
+fi
+
+if [ "$1" = "rpm-release" ]; then
+  [ -z "${ADD}" ] && echo release && exit
+  echo ${ADD}${CMTR:+~${CMTR}}${BLD}
+  exit
+fi
+
+  if [ -n "${ADD}" ]; then
+    if [ "$1" = "rpm-string" ]; then
+      echo ${TAG}-${ADD}${CMTR:+~${CMTR}}${BLD}
+    else
+      echo ${TAG}-${ADD}${CMT:+~${CMT}}${BLD}
+    fi
+  else
+    echo ${TAG}-release
+fi


### PR DESCRIPTION
- Implement `make dist` to create tarball, based on git-describe output as version
- Add `make pkg-rpm` and `make pkg-srpm` to create RPM packages
- Ignore more generated files