### PR TITLE
Use %configure macro on cligen.spec

### DIFF
--- a/extras/rpm/Makefile.in
+++ b/extras/rpm/Makefile.in
@@ -15,7 +15,6 @@ spec:
 
 srpm: spec
 	rpmbuild -bs \
-	  --define "_prefix @prefix@" \
 	  --define "_topdir $(RPMBUILD)" \
 	  --define "_version $(VERSION)" \
 	  --define "_release $(RELEASE)" \
@@ -24,7 +23,6 @@ srpm: spec
 
 RPM: spec
 	rpmbuild -bb \
-	  --define "_prefix @prefix@" \
 	  --define "_topdir $(RPMBUILD)" \
 	  --define "_version $(VERSION)" \
 	  --define "_release $(RELEASE)" \

--- a/extras/rpm/cligen.spec
+++ b/extras/rpm/cligen.spec
@@ -27,7 +27,7 @@ This package contains header files for CLIGEN.
 %setup
 
 %build
-./configure --prefix=%{_prefix} --libdir=%{_libdir}
+%configure
 make
 
 %install


### PR DESCRIPTION
%configure macro is defined with specific linux distribution defaults and should be used here