### PR TITLE
enable GCC printf format checking for cprintf.

### DIFF
--- a/cligen_buf.h
+++ b/cligen_buf.h
@@ -63,6 +63,11 @@ char *cbuf_get(cbuf *cb);
 int   cbuf_len(cbuf *cb);
 int   cbuf_buflen(cbuf *cb);
 int   cprintf(cbuf *cb, const char *format, ...);
+#if defined(__GNUC__) && __GNUC__ >= 3
+int   cprintf(cbuf *cb, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
+#else
+int   cprintf(cbuf *cb, const char *format, ...);
+#endif
 void  cbuf_reset(cbuf *cb);
 
 #endif /* _CLIGEN_BUF_H */


### PR DESCRIPTION
this allows gcc to match the format of the arguments to the format string and report mismatches.
