### PR TITLE
Improve permissions and strip binaries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -145,12 +145,12 @@ build.c:
 install: install-lib install-include
 
 install-bin: $(APPS)
-	install -m 755 -d $(DESTDIR)$(bindir) 
-	install -m 755 $(APPS) $(DESTDIR)$(bindir) 
+	install -m 0755 -d $(DESTDIR)$(bindir)
+	install -m 0755 -s $(APPS) $(DESTDIR)$(bindir)
 
 install-lib: $(MYLIB)
-	install -m 755 -d $(DESTDIR)$(libdir) 
-	install -m 755 $(MYLIB) $(DESTDIR)$(libdir) 
+	install -m 0755 -d $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libcligen.so.3
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libcligen.so
 
@@ -158,8 +158,8 @@ install-lib: $(MYLIB)
 # Installs include files in subdir called 'cligen'. Applications should include
 # <cligen/cligen.h>
 install-include: $(INCS)
-	install -d $(DESTDIR)$(includedir) 
-	install -m 644 $(INCS) $(DESTDIR)$(includedir) 
+	install -m 0755 -d $(DESTDIR)$(includedir)
+	install -m 0644 $(INCS) $(DESTDIR)$(includedir)
 
 uninstall: 
 	rm -f $(DESTDIR)$(libdir)/$(MYLIB)


### PR DESCRIPTION
- Use 0755 for directories
- Use 0644 for libraries and includes
- Use -s (strip) parameter when installing binaries and libraries