### PR TITLE
Add --enable-debug configure option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,6 +55,11 @@ CLIGEN_VERSION = @CLIGEN_VERSION@
 CLIGEN_MAJOR   = @CLIGEN_VERSION_MAJOR@
 CLIGEN_MINOR   = @CLIGEN_VERSION_MINOR@
 
+INSTALL_DIR = @INSTALL_DIR@
+INSTALL_INC = @INSTALL_INC@
+INSTALL_BIN = @INSTALL_BIN@
+INSTALL_LIB = @INSTALL_LIB@
+
 # Linker-name: libcligen.so
 # so-name: libcligen.so.3
 # real-name: libcligen.so.3.0
@@ -145,12 +150,12 @@ build.c:
 install: install-lib install-include
 
 install-bin: $(APPS)
-	install -m 0755 -d $(DESTDIR)$(bindir)
-	install -m 0755 -s $(APPS) $(DESTDIR)$(bindir)
+	$(INSTALL_DIR) $(DESTDIR)$(bindir)
+	$(INSTALL_BIN) $(APPS) $(DESTDIR)$(bindir)
 
 install-lib: $(MYLIB)
-	install -m 0755 -d $(DESTDIR)$(libdir)
-	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
+	$(INSTALL_DIR) $(DESTDIR)$(libdir)
+	$(INSTALL_LIB) $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libcligen.so.3
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libcligen.so
 
@@ -158,8 +163,8 @@ install-lib: $(MYLIB)
 # Installs include files in subdir called 'cligen'. Applications should include
 # <cligen/cligen.h>
 install-include: $(INCS)
-	install -m 0755 -d $(DESTDIR)$(includedir)
-	install -m 0644 $(INCS) $(DESTDIR)$(includedir)
+	$(INSTALL_DIR) $(DESTDIR)$(includedir)
+	$(INSTALL_INC) $(INCS) $(DESTDIR)$(includedir)
 
 uninstall: 
 	rm -f $(DESTDIR)$(libdir)/$(MYLIB)

--- a/configure
+++ b/configure
@@ -623,6 +623,10 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 EGREP
 GREP
+INSTALL_LIB
+INSTALL_BIN
+INSTALL_INC
+INSTALL_DIR
 RANLIB
 AR
 EXE_SUFFIX
@@ -697,6 +701,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_debug
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1326,6 +1331,12 @@ fi
 if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
+
+Optional Features:
+  --disable-option-checking  ignore unrecognized --enable/--with options
+  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
+  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-debug          Build with debug symbols, default: no
 
 Some influential environment variables:
   CC          C compiler command
@@ -2124,7 +2135,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 # Default CFLAGS unless set by environment.
-: ${CFLAGS="-O2"}
+unset default_cflags
+if test -z "$CFLAGS"; then
+   CFLAGS="-O2 -Wall"
+   default_cflags=1
+fi
 
 ac_config_headers="$ac_config_headers cligen_config.h"
 
@@ -3403,7 +3418,6 @@ $as_echo "Compiler is $CC" >&6; }
 LIBS="${LIBS} -L." #
 LDFLAGS=""
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
-CFLAGS="${CFLAGS} -Wall"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lm" >&5
 $as_echo_n "checking for main in -lm... " >&6; }
 if ${ac_cv_lib_m_main+:} false; then :
@@ -3448,6 +3462,37 @@ OBJ_SUFFIX=".o"
 AR_SUFFIX=".a"
 SH_SUFFIX=".so"
 AR="ar"
+INSTALL_DIR="install -m 0755 -d"
+INSTALL_INC="install -m 0644"
+INSTALL_BIN="install -m 0755"
+INSTALL_LIB="install -m 0644"
+
+# Check whether --enable-debug was given.
+if test "${enable_debug+set}" = set; then :
+  enableval=$enable_debug; case "${enableval}" in
+		yes)
+			debug=true
+			if test -n "$default_cflags"; then
+				CFLAGS="-g -O0 -Wall"
+			fi
+			;;
+		no)
+			debug=false
+			INSTALL_BIN="${INSTALL_BIN} -s"
+			INSTALL_LIB="${INSTALL_LIB} -s"
+			;;
+		*)
+			as_fn_error $? "bad value ${enableval} for --enable-debug" "$LINENO" 5
+			;;
+	esac
+else
+
+		debug=false
+		INSTALL_BIN="${INSTALL_BIN} -s"
+		INSTALL_LIB="${INSTALL_LIB} -s"
+
+fi
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: CFLAGS is $CFLAGS" >&5
 $as_echo "CFLAGS is $CFLAGS" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,11 @@
 AC_INIT(cligen.h)
 
 # Default CFLAGS unless set by environment.
-: ${CFLAGS="-O2"}
+unset default_cflags
+if test -z "$CFLAGS"; then
+   CFLAGS="-O2 -Wall"
+   default_cflags=1
+fi
 
 AC_CONFIG_HEADER(cligen_config.h)
 
@@ -70,6 +74,10 @@ AC_SUBST(SH_SUFFIX)
 AC_SUBST(EXE_SUFFIX)
 AC_SUBST(AR)
 AC_SUBST(RANLIB)
+AC_SUBST(INSTALL_DIR)
+AC_SUBST(INSTALL_INC)
+AC_SUBST(INSTALL_BIN)
+AC_SUBST(INSTALL_LIB)
 #
 
 echo "$host_cpu $host_vendor $host_os"
@@ -89,13 +97,40 @@ AC_MSG_RESULT(Compiler is $CC)
 LIBS="${LIBS} -L." # 
 LDFLAGS=""
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
-CFLAGS="${CFLAGS} -Wall" 
 AC_CHECK_LIB(m, main)
 EXE_SUFFIX=""
 OBJ_SUFFIX=".o"
 AR_SUFFIX=".a"
 SH_SUFFIX=".so"
 AR="ar"
+INSTALL_DIR="install -m 0755 -d"
+INSTALL_INC="install -m 0644"
+INSTALL_BIN="install -m 0755"
+INSTALL_LIB="install -m 0644"
+
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],
+	[Build with debug symbols, default: no]),
+	[case "${enableval}" in
+		yes)
+			debug=true
+			if test -n "$default_cflags"; then
+				CFLAGS="-g -O0 -Wall"
+			fi
+			;;
+		no)
+			debug=false
+			INSTALL_BIN="${INSTALL_BIN} -s"
+			INSTALL_LIB="${INSTALL_LIB} -s"
+			;;
+		*)
+			AC_MSG_ERROR([bad value ${enableval} for --enable-debug])
+			;;
+	esac],
+	[
+		debug=false
+		INSTALL_BIN="${INSTALL_BIN} -s"
+		INSTALL_LIB="${INSTALL_LIB} -s"
+	])
 
 AC_MSG_RESULT(CFLAGS is $CFLAGS)	
 AC_MSG_RESULT(CPPFLAGS is $CPPFLAGS)	


### PR DESCRIPTION
When passed to configure this option will set default CFLAGS to "-g -O0 -Wall" and will remove "-s" from install command when installing binaries and libraries