### PR TITLE
handle SIGWINCH when not waiting for a read() to complete

### DIFF
--- a/cligen_handle.c
+++ b/cligen_handle.c
@@ -87,6 +87,8 @@ cligen_gwinsz(cligen_handle h)
 void
 sigwinch_handler(int arg)
 {
+    /* the handle parameter isn't used */
+    cligen_gwinsz(0);
 }
 
 /*! This is the first call the CLIgen API and returns a handle. 


### PR DESCRIPTION
SIGWINCH is handled in the console read() call, and there is a signal
handler for it in other cases. However, the handler was empty, so
a screen resize was ignored when not in read(). Add a call to check
the screen dimensions into the signal handler to fix.

Note, there is a parameter h on the handler, but it is not used
in the called routine, so it seems ok just to pass 0.