### PR TITLE
Add escaping API call

### DIFF
--- a/cligen_expand.h
+++ b/cligen_expand.h
@@ -56,6 +56,7 @@ int pt_expand_cleanup_2(parse_tree pt);
 int pt_expand_add(cg_obj *co, parse_tree ptn);
 int reference_path_match(cg_obj *co1, parse_tree pt0, cg_obj **co0p);
 int transform_var_to_cmd(cg_obj *co, char *cmd, char *comment);
+const char* cligen_escape(const char* s);
 
 #endif /* _CLIGEN_EXPAND_H_ */
 

--- a/cligen_tutorial.tex
+++ b/cligen_tutorial.tex
@@ -1450,6 +1450,9 @@ This appendix contains a list of cligen API functions. There are several more wh
 {\tt int cligen\_expand\_str2fn(parse\_tree pt, expand\_str2fn\_t *str2fn, void *fnarg)}\\*
 \emph{  Register functions for variable completion in parse-tree using translator}
 
+{\tt const char* cligen\_escape(const char* s)}\\*
+\emph{  Escape special characters in a string, if necessary (SPC, TAB, ?, \textbackslash)}
+
 {\tt char *cv\_name\_get(cg\_var *cv)}\\*
 \emph{ Get name of cligen variable cv}
 


### PR DESCRIPTION
If expansion routine produces a string with ' ', '\t', '?', or '\\',
inserting the string into command line breaks command.  Such string must
be escaped before being used for completion.  Escaping API is exposed, so
that users may escape strings irrelevant of which characters CLIgen
considers special.  An example would be generating CLI script from
configuration database (`show configuration cli` in Clixon demo).