### PR TITLE
Add `const` to `char*` parameters that are not mutated

### DIFF
--- a/cligen_file.c
+++ b/cligen_file.c
@@ -225,7 +225,7 @@ str2fn(const char *name,
  */
 static int
 cli_expand_cb(cligen_handle h,
-              char         *fn_str,
+              const char   *fn_str,
               cvec         *cvv,
               cvec         *argv,
               cvec         *commands,     /* vector of function strings */

--- a/cligen_object.h
+++ b/cligen_object.h
@@ -95,12 +95,12 @@ enum cg_objtype{
            1 if did not handle expand
           -1 on error.
 */
-typedef int (expand_cb)(cligen_handle h,       /* handler: cligen or userhandle */
-                        char         *name,    /* name of this function (in text) */
-                        cvec         *cvv,     /* vars vector of values in command */
-                        cvec         *argv,    /* argument vector given to callback */
-                        cvec         *commands,/* vector of commands */
-                        cvec         *helptexts /* vector of help-texts */
+typedef int (expand_cb)(cligen_handle h,             /* handler: cligen or userhandle */
+                        const char   *name,          /* name of this function (in text) */
+                        cvec         *cvv,           /* vars vector of values in command */
+                        cvec         *argv,          /* argument vector given to callback */
+                        cvec         *commands,      /* vector of commands */
+                        cvec         *helptexts      /* vector of help-texts */
                         );
 
 #if 1  // XXX backward-compatible

--- a/cligen_parse.h
+++ b/cligen_parse.h
@@ -99,7 +99,7 @@ int cgy_exit(cligen_yacc *cy);
 
 int cligen_parselex(void *_ya);
 int cligen_parseparse(void *);
-void cligen_parseerror(void *_ya, char*);
+void cligen_parseerror(void *_ya, const char*);
 int cligen_parse_debug(int d);
 
 #endif  /* _CLIGEN_PARSE_H_ */

--- a/cligen_parse.y
+++ b/cligen_parse.y
@@ -135,7 +135,7 @@ cligen_parse_debug(int d)
  * @param[in]  cy  CLIgen yacc parse struct
  */
 void cligen_parseerror(void *_cy,
-                       char *s)
+                       const char *s)
 {
     cligen_yacc *cy = (cligen_yacc *)_cy;
 

--- a/cligen_syntax.c
+++ b/cligen_syntax.c
@@ -73,7 +73,7 @@ int
 clispec_parse_str(cligen_handle h,
                   const char   *str,
                   const char   *name,
-                  char         *treename,
+                  const char   *treename,
                   parse_tree   *ptp,
                   cvec         *cvv)
 {
@@ -176,8 +176,8 @@ clispec_parse_str(cligen_handle h,
 int
 clispec_parse_file(cligen_handle h,
                    FILE         *f,
-                   char         *name,
-                   char         *treename,
+                   const char   *name,
+                   const char   *treename,
                    parse_tree   *pt,
                    cvec         *cvv)
 {

--- a/cligen_syntax.h
+++ b/cligen_syntax.h
@@ -65,14 +65,14 @@ int
 clispec_parse_str(cligen_handle  h,
                   const char    *str,
                   const char    *name,
-                  char          *treename,
+                  const char    *treename,
                   parse_tree    *pt,
                   cvec          *globals);
 int
 clispec_parse_file(cligen_handle h,
                    FILE         *f,
-                   char         *name,
-                   char         *treename,
+                   const char   *name,
+                   const char   *treename,
                    parse_tree   *obsolete,
                    cvec         *globals);
 

--- a/cligen_tutorial.c
+++ b/cligen_tutorial.c
@@ -229,7 +229,7 @@ str2fn(const char *name,
  */
 int
 cli_expand_cb(cligen_handle h,
-              char         *fn_str,
+              const char   *fn_str,
               cvec         *cvv,
               cvec         *argv,
               cvec         *commands,     /* vector of function strings */


### PR DESCRIPTION
Marked read-only string parameters as const in the public API:
- `expand_cb` typedef: `name` parameter
- `clispec_parse_str`: `treename` parameter
- `clispec_parse_file`: `name` and `treename` parameters
- `cligen_parseerror`: error string parameter (`s`)

Updated implementations and example callbacks to match.